### PR TITLE
Api provides functionality to create user account

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,18 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
 ActiveRecord::Schema.define(version: 2021_09_30_132742) do
+
+  # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "products", force: :cascade do |t|
@@ -37,4 +51,5 @@ ActiveRecord::Schema.define(version: 2021_09_30_132742) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
+
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     price { 40.0 }
     description { "MyString" }
     image { "https://picsum.photos/200" }
-    category { "MyString" }    
+    category { "MyString" }
   end
 end

--- a/spec/requests/api/registration_spec.rb
+++ b/spec/requests/api/registration_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe 'POST /api/auth/' do
+  # let!(:user) { create(:user) }
+
+  describe 'with successfull registration' do
+    before do
+      post '/api/auth/',
+           params: {
+             email: 'user@email.com',
+             password: 'password',
+             password_confirmation: 'password',
+             confirm_success_url: 'placeholder'
+           }
+    end
+
+    it 'is expected to return a 200 response status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to return an access token to the user' do
+      # binding.pry
+      expect(response.header['access-token']).not_to eq nil
+    end
+  end
+end

--- a/spec/requests/api/registration_spec.rb
+++ b/spec/requests/api/registration_spec.rb
@@ -1,27 +1,41 @@
-RSpec.describe 'POST /api/auth/' do
-  # let!(:user) { create(:user) }
-
-  describe 'with successfull registration' do
+RSpec.describe "POST /api/auth/" do
+  describe "with successfull registration" do
     before do
-      post '/api/auth/',
+      post "/api/auth/",
            params: {
-             email: 'user@email.com',
-             password: 'password',
-             password_confirmation: 'password',
-             confirm_success_url: 'placeholder'
+             email: "user@email.com",
+             password: "password",
+             password_confirmation: "password",
+             confirm_success_url: "placeholder",
            }
     end
 
-    it 'is expected to return a 200 response status' do
+    it "is expected to return a 200 response status" do
       expect(response).to have_http_status 200
     end
 
-    it 'is expected to return an access token to the user' do      
-      expect(response.header['access-token']).not_to eq nil
+    it "is expected to return an access token to the user" do
+      expect(response.header["access-token"]).not_to eq nil
     end
 
-    it 'is expected to that users databse contains new user' do
-      expect(User.all.first.email).to eq 'user@email.com'
+    it "is expected to that users databse contains new user" do
+      expect(User.all.first.email).to eq "user@email.com"
+    end
+  end
+
+  describe "with unsuccessfull registration" do
+    before do
+      post "/api/auth/",
+           params: {
+             email: "user@email.com",
+             password: "password",
+             password_confirmation: "wrong password",
+             confirm_success_url: "placeholder",
+           }
+    end
+
+    it "is expected to return an error message when password dont match" do
+      expect(response_json["errors"]["full_messages"]).to eq ["Password confirmation doesn't match Password"]
     end
   end
 end

--- a/spec/requests/api/registration_spec.rb
+++ b/spec/requests/api/registration_spec.rb
@@ -16,9 +16,12 @@ RSpec.describe 'POST /api/auth/' do
       expect(response).to have_http_status 200
     end
 
-    it 'is expected to return an access token to the user' do
-      # binding.pry
+    it 'is expected to return an access token to the user' do      
       expect(response.header['access-token']).not_to eq nil
+    end
+
+    it 'is expected to that users databse contains new user' do
+      expect(User.all.first.email).to eq 'user@email.com'
     end
   end
 end


### PR DESCRIPTION
- Creates user registration spec with partial happy path
- Test to return an access token to the user
- Test sad path where user enter wrong password
- Test to see if user is created in the database

```
As a restaurant API
In order to give visitors access to order functionality
I would like to be able to allow visitors to create an account
```
Pivotal Tracker: https://www.pivotaltracker.com/story/show/179770071